### PR TITLE
Use context to ingest enviroment variables.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
           command: "echo 'Skipping linter until theres something to lint';"
   deploy:
     <<: *defaults
+    context: unmock-publish-docusaurus
     steps:
       - checkout: *root-checkout
       - run: *root-yarn


### PR DESCRIPTION
- [ ]  Persist the build to the workspace to avoid extra build.