### PR TITLE
Update the docs on DSL for 0.1.6.

### DIFF
--- a/docs/hello.md
+++ b/docs/hello.md
@@ -81,7 +81,7 @@ This simple example contains everything we need to be up and running with Unmock
 
 ## Returning a specific value
 
-With Unmock, you no longer have to worry about mocking the response and/or overriding your code's default behaviour. However, we often want to check against our code against specific values. This is where the [state management](basic.md) for `unmock` kicks in. To complete our introduction, add the following to `hello.test.js`:
+With Unmock, you no longer have to worry about mocking the response and/or overriding your code's default behaviour. However, we often want to check against our code against specific values. This is where the [state management](state-basic.md) for `unmock` kicks in. To complete our introduction, add the following to `hello.test.js`:
 
 ```js
 // ...
@@ -98,4 +98,4 @@ test("setting a value for endpoint", async () => {
 ## Next steps
 
 1. Learn how to define [services](layout.md)
-1. Learn how to define [state](basic.md) for a service on per-test basis
+1. Learn how to define [state](state-basic.md) for a service on per-test basis

--- a/docs/state-advanced.md
+++ b/docs/state-advanced.md
@@ -1,10 +1,10 @@
 ---
 id: state:advanced
 title: Advanced state management with DSL
-sidebar_label: DSL
+sidebar_label: Advanced DSL
 ---
 
-Setting the response body as described in the [previous section](state-basic.md) is often sufficient, but sometimes you need to more control to test, for example, the behaviour for status code 500 or start with 10 users in a service. This can be achieved with the unmock DSL. All DSL elements are prefixed with the dollar sign (`$`).
+Modifying the response body or status code as described in the [previous section](state-basic.md) is often sufficient, but sometimes you need more control to test, for example, the behaviour for a service with 10 users. This can be achieved with the Unmock DSL. All DSL elements are prefixed with the dollar sign (`$`).
 
 ## Top-level DSL
 
@@ -12,7 +12,7 @@ Top-level DSL is not specific to any property in the response body and can there
 
 ## `$code`
 
-Using `$code`, you can specify the status code returned by the service for a call to a given endpoint. The response code must exist in the service specification.
+The DSL element `$code` was introduced in the [previous section]("./state-basic.md") for specifying the status code returned by the service for a call to a given endpoint. Note that the response code must exist in the service specification.
 
 ```javascript
 // Returns a 500 error on requests to `/pets/5`
@@ -46,7 +46,7 @@ states.github("/search/repositories", {
 });
 ```
 
-## State middleware
+## State DSL middleware
 
 Unmock currently offers two middleware functions. The default one is the object-notation middleware. You've seen it in the [basic usage](state-basic.md) - you pass key-value pairs as a state. The other one is a string middleware. Both are found under `unmock.middleware`.
 
@@ -54,18 +54,19 @@ We roll out more middlewares as are necessary - please [let us know](https://git
 
 ### Object-notation middleware
 
-This is the default notation. It matches many content type requests - `application/json`, `application/xml`, `multipart/form-data`, etc. It is the default exported middleware in `unmock.middleware`, and it is automatically used if no middleware is specified.
+This is the default notation. It matches many content type requests - `application/json`, `application/xml`, `multipart/form-data`, etc. It is the default exported middleware in `unmock.dsl`, and it is automatically used if no middleware is specified.
 
 It works by abstracting away certain elements that are present in the OpenAPI specification, but are abstracted away from the response. Thus, instead of using `{ items: { properties: { id: 5 } } }`, one may simply use `{ id: 5 }`.
 
 ### String middleware
 
-Many other content types have a simple schema for a response. `text/plain`, `image/*`, `application/octet-stream` and many more have a `type: string` (and additional `format`) specified as their schema. To set a state for these responses, where we don't have a key, you may use the `textMW` (we're very creative!).
+Many other content types have a simple schema for a response. `text/plain`, `image/*`, `application/octet-stream` and many more have a `type: string` (and additional `format`) specified as their schema. To set a state for these responses, where we don't have a key, you may use the `textResponse` (we're very creative!).
 
 The text middleware accepts a string input, and optional object for top-level DSL.
 
 ```javascript
-const textMW = unmock.middleware.textResponse;
-states.petstore(textMW("foo"));
-states.petstore("/pets/*", textResponse("bar", { $code: 200 }));
+// import { dsl: textResponse } from "unmock-node";  // ES6
+const { dsl: textResponse } = require();
+states.petstore(textResponse("foo")); // Same as `states.petstore("foo")
+states.petstore("/pets/*", textResponse("bar", { $code: 200 })); // Same as `states.petstore("/pets/*", { $code: 200 }).petstore("/pets/*", "bar");
 ```

--- a/docs/state-advanced.md
+++ b/docs/state-advanced.md
@@ -1,10 +1,10 @@
 ---
-id: advanced
+id: state:advanced
 title: Advanced state management with DSL
 sidebar_label: DSL
 ---
 
-Setting the response body as described in the [previous section](basic.md) is often sufficient, but sometimes you need to more control to test, for example, the behaviour for status code 500 or start with 10 users in a service. This can be achieved with the unmock DSL. All DSL elements are prefixed with the dollar sign (`$`).
+Setting the response body as described in the [previous section](state-basic.md) is often sufficient, but sometimes you need to more control to test, for example, the behaviour for status code 500 or start with 10 users in a service. This can be achieved with the unmock DSL. All DSL elements are prefixed with the dollar sign (`$`).
 
 ## Top-level DSL
 
@@ -48,7 +48,7 @@ states.github("/search/repositories", {
 
 ## State middleware
 
-Unmock currently offers two middleware functions. The default one is the object-notation middleware. You've seen it in the [basic usage](basic.md) - you pass key-value pairs as a state. The other one is a string middleware. Both are found under `unmock.middleware`.
+Unmock currently offers two middleware functions. The default one is the object-notation middleware. You've seen it in the [basic usage](state-basic.md) - you pass key-value pairs as a state. The other one is a string middleware. Both are found under `unmock.middleware`.
 
 We roll out more middlewares as are necessary - please [let us know](https://github.com/unmock/unmock-js/issues) if you're missing anything!
 

--- a/docs/state-basic.md
+++ b/docs/state-basic.md
@@ -1,5 +1,5 @@
 ---
-id: basic
+id: state:basic
 title: Setting state
 sidebar_label: Setting state
 ---

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -3,7 +3,7 @@
     "Getting started": ["introduction", "hello", "faq"],
     "Activation": ["installation", "activation"],
     "Services": ["layout", "loas3", "fetching"],
-    "State": ["basic", "advanced"],
+    "State": ["state:basic", "state:advanced"],
     "Roadmap": ["roadmap", "contributing", "about"]
   }
 }


### PR DESCRIPTION
- Rename `basic.md` -> `state-basic.md` and `advanced.md -> state-advanced.md` for easier access
- Rewrite the section on basic state management to include sections on specifying response bodies and status code (setting the status code is basic usage)
- Fix references to `unmock.middleware`
- Does not contain any instructions on using functions to define the state