### PR TITLE
Increase Gitter z-index.

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -14,3 +14,10 @@
 
 @media only screen and (min-width: 1500px) {
 }
+
+.gitter-chat-embed {
+  z-index: 99999;
+}
+.gitter-open-chat-button {
+  z-index: 99999;
+}


### PR DESCRIPTION
Docusaurus header has 9999 so Gitter needs 99999 to not get buried behind Docusaurus header 😬 