### PR TITLE
fix: readability improvements

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -4,7 +4,7 @@ title: A Motivating Example
 sidebar_label: A Motivating Example
 ---
 
-Below is a fully functional example of Unmock in action! You can also view the example on github [here](https://github.com/unmock/unmock-examples/tree/master/starter) and inspect its output results [here](http://htmlpreview.github.io/?https://github.com/unmock/unmock-examples/blob/add-report-to-git/starter/__unmock__/unmock-report.html). It shows the most important concepts of Unmock all rolled into one example.
+Below is a fully functional example of Unmock in action! You can also [view the example](https://github.com/unmock/unmock-examples/tree/master/starter) on GitHub and inspect its [output results](http://htmlpreview.github.io/?https://github.com/unmock/unmock-examples/blob/add-report-to-git/starter/__unmock__/unmock-report.html). It shows the most important concepts of Unmock, all rolled into one example.
 
 The example will use TypeScript syntax, although the same is possible in JavaScript. First, let's import everything we need.
 

--- a/docs/fuzz.md
+++ b/docs/fuzz.md
@@ -4,7 +4,7 @@ title: Fuzz Testing
 sidebar_label: Fuzz Testing
 ---
 
-Because Unmock generates random responses, it is not very useful to test out just one. The real power of unmock comes from testing many different outcomes of interactions with an API.  To do this, unmock supports fuzz testing, or the testing of multiple random outcomes, with `unmock.runner`.
+Because Unmock generates random responses, it is not very useful to test out just one. The real power of Unmock comes from testing many different outcomes of interactions with an API.  To do this, `unmock` supports fuzz testing, or the testing of multiple random outcomes, with `unmock.runner`.
 
 ```javascript
 import unmock, { u, transform, runner } from "unmock";

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -4,9 +4,9 @@ title: More Resources
 sidebar_label: More Resources
 ---
 
-In addition to this documentation, the following resources are available to help you learn unmock.
+In addition to this documentation, the following resources are available to help you learn Unmock.
 
-- [Typescript koans](https://github.com/unmock/unmock-ts-koans), a step-by-step wade into unmock using the popular koans method.
+- [TypeScript koans](https://github.com/unmock/unmock-ts-koans), a step-by-step wade into Unmock using the popular koans method.
 - [Katacoda](https://www.katacoda.com/unmock/scenarios/introduction
-), a gentle introduction to unmock that you can do entirely on the web.
-- [Our README](https://github.com/unmock/unmock-js), which is basically this documentation in condensed form.
+), a gentle introduction to Unmock that you can do entirely on the web.
+- [Our README](https://github.com/unmock/unmock-js) is basically this documentation in a condensed format.

--- a/docs/state.md
+++ b/docs/state.md
@@ -28,7 +28,7 @@ In most cases, resetting and redefining the service is all you need. However, wh
 
 ## Setting state for a service
 
-Let's revisit the example above, and use the state to make sure we are only returning 200.
+Let's revisit the example above, and use the state to make sure we are only returning `200`.
 
 ```javascript
 import unmock, { u, transform } from "unmock";


### PR DESCRIPTION
Various smaller text improvements for the documentation.

Goal was to improve the consistency of the content & naming conventions.

## Git commits

### fix: improve text readability

- Improve text structure by changing the link text from "here" to "view the example"
- Improve text structure by changing the link text from "here" to "output results"
- Change brand name from `github` to `GitHub`
- Add missing comma to improve clarity of the text

### fix(resources): readability improvements

- Readability improvements
- Fix brand name from "Typescript" to "TypeScript"
- Fix brand name from "unmock" to "Unmock"

### fix(state): readability improvements

- Readability improvements
  - Markdown for the `200` return value for visual consistency

### fix(fuzz): readability improvements

- Readability improvements
  - Fix brand name from "unmock" to "Unmock"
  - Markdown for the `unmock` package name
