### PR TITLE
Removed isolating language from docs

### DIFF
--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -4,7 +4,7 @@ title: Great Expectations
 sidebar_label: Great Expectations
 ---
 
-Now that you know how to define services in Unmock, it would be useful to assert things about how they are used. When services are defined and loaded in Unmock, they automagically reside in the `unmock.services` object. These service objects contain lots of useful properties for you to write simple and effective tests.
+Now that you know how to define services in Unmock, it would be useful to assert things about how they are used. When services are defined and loaded in Unmock, they automagically reside in the `unmock.services` object. These service objects contain lots of useful properties for you to write clear and effective tests.
 
 ## Spying
 
@@ -19,11 +19,11 @@ const {
 const githubSpy = github.spy;
 ```
 
-An unmock spy has all the properties documented in the [SinonJS documentation](https://sinonjs.org/releases/v7.4.1/spies/). In addition to this, it has some useful functions that make working with HTTP(S) related concepts, like request or response bodies, easy.
+An unmock spy has all the properties documented in the [SinonJS documentation](https://sinonjs.org/releases/v7.4.1/spies/). In addition to this, it has some useful functions that can help when working with HTTP(S) related concepts, like request or response bodies.
 
 ## Paths and Headers and Bodies, Oh My!
 
-When working with network calls, we will often want to make assertions like the right path was called, the right header was used or the right body was returned. Unmock spies have some useful functions for this that follow a simple convention.
+When working with network calls, we will often want to make assertions like the right path was called, the right header was used or the right body was returned. Unmock spies have some useful functions for this that follow a basic convention.
 
 > `<method><Op>(/* matcher */)`
 
@@ -35,7 +35,7 @@ When working with network calls, we will often want to make assertions like the 
   import { sinon } from "unmock";
   ```
 
-Below is a simple test using `expect` together with `postRequestBody` and `postResponseBody` to verify the request body of a post request as well as the code output.
+Below is a test using `expect` together with `postRequestBody` and `postResponseBody` to verify the request body of a post request as well as the code output.
 
 <!--DOCUSAURUS_CODE_TABS-->
 
@@ -134,7 +134,7 @@ paths:
 
 ## Advanced usage
 
-When possible, you should use functions like `postRequestBody` or `postRequestHost` above to reason about HTTP(S) calls. They make your test easy to read and maintain. However, sometimes, you may need to make more fine grained assertions having to do with the order of network calls or other subtleties. In this case, you'll want to use the full power of SinonJS spies.
+When possible, you should use functions like `postRequestBody` or `postRequestHost` above to reason about HTTP(S) calls. They make your test easier to read and maintain. However, sometimes, you may need to make more fine grained assertions having to do with the order of network calls or other subtleties. In this case, you'll want to use the full power of SinonJS spies.
 
 Below is a test that uses only SinonJS spy properties such as `callCount` and `firstCall` to inspect [spy calls](https://sinonjs.org/releases/v7.4.1/spy-call/) and their return values (`firstCall.returnValue.body`).
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -30,7 +30,7 @@ $ npm install --save-dev unmock
 
 ## Turning Unmock on and off
 
-To turn Unmock on in any given file, simply call `unmock.on()`. For example, if you are using Jest, it is a good idea to turn Unmock on before each test or before all tests.
+To turn Unmock on in any given file, call `unmock.on()`. For example, if you are using Jest, it is a good idea to turn Unmock on before each test or before all tests.
 
 ```javascript
 const unmock = require("unmock").default;

--- a/docs/jest-reporter.md
+++ b/docs/jest-reporter.md
@@ -4,7 +4,7 @@ title: Jest reporter
 sidebar_label: Jest Reporter
 ---
 
-Unmock includes a Jest reporter for easy integration with [Jest](https://jestjs.io/), a delightful JS testing framework. When run with Jest, the reporter outputs an HTML report of the HTTP traffic made by each test. It has never been easier to see how your code interacts with the outside world!
+Unmock includes a Jest reporter for easy integration with [Jest](https://jestjs.io/), a delightful JS testing framework. When run with Jest, the reporter outputs an HTML report of the HTTP traffic made by each test.
 
 ## Installation
 

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -25,7 +25,7 @@ We'll talk about how to fetch the GitHub and other service definitions in [Fetch
 
 ## Service specification
 
-In Unmock, services are simply documents designed according to the [OpenAPI 3.0.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md).
+In Unmock, services are documents designed according to the [OpenAPI 3.0.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md).
 
 Unmock is able to turn most OpenAPI specifications into viable mocks without any tinkering, but there are a few service extensions we provide to make the mocks moxier. Unmock uses the `x-` pattern defined in the [OpenAPI specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#specificationExtensions).
 

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -28,7 +28,7 @@ Any valid OpenAPI 3 specification can be added to your project this way. Many AP
 
 ## Lazy Open API 3 (loas3)
 
-To help overcome the verbosity and tedium of writing an OpenAPI spec, Unmock can process [`loas3`](https://www.github.com/unmock/loas3), or Lazy OpenAPI 3, a syntactic superset of OpenAPI 3.0.0. This section gives a quick primer of the `loas3` specification. In addition to being easier to read and write, the specification usually results in documents that are 50% the size (or less!) of their more verbose OpenAPI counterparts.
+To help overcome the verbosity and tedium of writing an OpenAPI spec, Unmock can process [`loas3`](https://www.github.com/unmock/loas3), or Lazy OpenAPI 3, a syntactic superset of OpenAPI 3.0.0. This section gives a quick primer of the `loas3` specification. In addition to being less demanding to read and write, the specification usually results in documents that are 50% the size (or less!) of their more verbose OpenAPI counterparts.
 
 ### Cascading objects
 
@@ -163,7 +163,7 @@ paths:
 
 #### Supremely lazy
 
-For the unbearably, pathologically, irrecoverably lazy, you can just list the parameters as key-value pairs. They default to query unless they are in the enclosing path.
+For the unbearably, pathologically, irrecoverably lazy, you can list the parameters as key-value pairs. They default to query unless they are in the enclosing path.
 
 <!--DOCUSAURUS_CODE_TABS-->
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -24,7 +24,7 @@ unmock
 
 That's all well and good, but sometimes, you'd like for a service to behave more specifically, like **only** responding with a given code or **only** responding with an array of size ten.  You can do this in one of two ways: calling `service.reset()` and redefining the service *or* using `service.state`.
 
-In most cases, resetting and redefining the service is all you need. However, when you are working with OpenAPI, or when you have a complex service defined, using the `state` can be a simple and elegant solution.
+In most cases, resetting and redefining the service is all you need. However, when you are working with OpenAPI, or when you have a complex service defined, using the `state` can be an elegant solution.
 
 ## Setting state for a service
 
@@ -91,7 +91,7 @@ myapi.state(
 
 We've overridden the body so that the value at `body.name` is `"Carolyn"` and `body.zodiac.ascendenet` is `"Libra"`. `lens` acts as a lens that zooms in on part of an object, not unlike the concept of lenses [optics](https://en.wikibooks.org/wiki/Haskell/Lenses_and_functional_references) from functional programming.
 
-One gotchya is how to zoom in on objects with variable numbers of propreties. To zoom in on an index of an array, just use the number. To zoom in on every element of the array, use the `unmock.Arr` symbol in the lens, ie `[Arr, "id"]` to set the `id` of every element in a top-level array. To zoom in on every element of a Record (an object with key-value pairs) use `Addl`, ie `[Addl, "id"]` to set the `id` of every element in a record.
+One gotchya is how to zoom in on objects with variable numbers of propreties. To zoom in on an index of an array, use the number. To zoom in on every element of the array, use the `unmock.Arr` symbol in the lens, ie `[Arr, "id"]` to set the `id` of every element in a top-level array. To zoom in on every element of a Record (an object with key-value pairs) use `Addl`, ie `[Addl, "id"]` to set the `id` of every element in a record.
 
 In your IDE, you can inspect the signature of `responseBody` to see the various parts of a body you can set. You can make a property required, set the minimum number of items in an array, and lots more!
 

--- a/docs/unmock.md
+++ b/docs/unmock.md
@@ -6,7 +6,7 @@ sidebar_label: Defining Services
 
 Unmock provides a programmatic and interactive way of building services across multiple test files. A **service** in Unmock is any REST API that is being mocked - a microservice, [openweathermap.org](https://openweathermap.org/api), etc.
 
-The service-definition syntax is a subset [`nock`](https://github.com/nock/nock) and lives under the object `unmock.nock`.  Here is a simple example of a GET request in unmock.
+The service-definition syntax is a subset [`nock`](https://github.com/nock/nock) and lives under the object `unmock.nock`.  Here is an example of a GET request in unmock.
 
 ```javascript
 // mytest.js


### PR DESCRIPTION
For Hacktoberfest this year, I'm focusing on removing words like simple, easy, just, etc. from open source documentation. And since, according to the schedule, I was supposed to make a smol docs PR (on Tuesday oops) - I figured this is the perfect opportunity 🎃 