### PR TITLE
Add Code of Conduct page and link in footer

### DIFF
--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,0 +1,7 @@
+---
+id: code-of-conduct
+title: Unmock Community Code of Conduct
+sidebar_label: Code of Conduct
+---
+
+

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -4,4 +4,102 @@ title: Unmock Community Code of Conduct
 sidebar_label: Code of Conduct
 ---
 
+## Short Form Code of Conduct
+The Unmock community is dedicated to providing a safe, inclusive, welcoming, and harassment-free space and experience for all community participants, regardless of gender identity and expression, sexual orientation, disability, physical appearance, socioeconomic status, body size, ethnicity, nationality, level of experience, age, religion (or lack thereof), or other identity markers. 
 
+Our Code of Conduct exists because of that dedication, and we do not tolerate harassment in any form. If you need to report an incident, please refer to our [reporting guidelines](https://github.com/unmock/code-of-conduct/blob/master/incident-reporting.md).
+
+## Long Form Code of Conduct
+The Unmock community is dedicated to providing a safe, inclusive, welcoming, and harassment-free space and experience for all community participants, regardless of gender identity and expression, sexual orientation, disability, physical appearance, socioeconomic status, body size, ethnicity, nationality, level of experience, age, or religion (or lack thereof). Our Code of Conduct exists because of that dedication, and we do not tolerate harassment in any form.
+
+This Code of Conduct applies to all Unmock community spaces, including Unmock open source repositories, online communication channels such as Gitter or social media, any Unmock community events and meetups, online and offline, as well as in one-on-one communications pertaining to Unmock community business. Participants violating our Code of Conduct may be penalized or expelled at the discretion of community moderators.
+
+Some Unmock community spaces may have additional rules in place, which are posted publicly for participants. Participants are responsible for knowing and abiding by these rules. We invite all those who participate in the Unmock community to help us create safe and positive community experiences.
+
+Consequences for noncompliance with the Code of Conduct may include a discussion with moderators, mediation with the participant you may have harassed, or as an absolute last resort, a ban from the community.
+
+### Behavior
+Appropriate behavior contributes to the health, safety, and longevity of the Unmock community and includes:
+
+- Participating in an authentic and empathetic way.
+- Representing the Unmock community in a positive, professional way.
+- Using welcoming and inclusive language.
+- Exercising consideration and respect in your speech and actions.
+- Refraining from demeaning, discriminatory, or harassing behavior and speech.
+- Being mindful of your surroundings and of your fellow participants.
+- Considering what is best for the community.
+- Alerting community moderators if you notice a dangerous situation, someone in distress, or unresolved violations of this Code of Conduct.
+- Refraining from doing something you wouldn’t do in another professional situation.
+- Remembering that community event venues may be shared with members of the public; being respectful to all patrons of these locations.
+- Keeping an open and curious mind without making assumptions about others.
+- Attempting collaboration before conflict.
+- Gracefully accepting well-communicated constructive criticism.
+
+Harassment includes:
+
+- Discriminatory language and actions that reinforce social structures of domination related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, age, race, religion (or lack thereof), or other identity markers.
+- Excessive trolling or sustained, uninvited disruption.
+- Insults or personal attacks.
+- Violent or personally objectifying material.
+- Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate.
+- Unwelcome sexual attention.
+- Physical contact and simulated physical contact (e.g., textual descriptions like “backrub”) without consent or after a request to stop.
+- Violent language or threats of violence.
+- Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm.
+- Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
+- Deliberate misgendering or use of “dead” or rejected names.
+- Pattern of inappropriate social contact, such as requesting/assuming unprofessional levels of intimacy with others.
+- Continued one-on-one communication after requests to cease.
+- Deliberate “outing” of any aspect of a person’s identity without their consent.
+- Threatening to post or posting other people’s personally identifiable information without consent.
+- Publication of non-harassing private communication without consent.
+- Blogging, tweeting, or otherwise communicating with intent to harm someone’s reputation, i.e., “making an example” of a community participant.
+- Intimidation, stalking, or following.
+- Harassing or unwanted photography or recording, including logging online activity for harassment purposes.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+- Advocating for, or encouraging, any of the above behavior.
+
+### Procedures
+
+[Guidelines for Incident Reporting](https://github.com/unmock/code-of-conduct/blob/master/incident-reporting.md)
+
+### Enforcement
+- Participants asked to stop any harassing behavior are expected to comply immediately, even if participants do not agree with or fully acknowledge the behavior being reported.
+- If a participant violates the Code of Conduct, community moderators may take any action they deem appropriate to maintaining a welcoming environment for all participants, up to and including expulsion from an event and/or the community and identification of the participant as a violator. If a community moderator is not available at an event, the event organizer should ask violators to leave and then report the situation to community moderators for further deliberation.
+- There will always be at least one moderator “on-call” if no moderators are able to attend an event
+Community moderators and/or event organizers may take action to redress anything designed to, or with the clear impact of, disrupting or making an environment hostile for any participants.
+- We expect participants to respect the Code of Conduct in all Unmock communities and at all Unmock or Unmock related events.
+
+### Moderators
+Code of Conduct moderators will:
+
+- Always be at least two people working together to respond to violations.
+- Respond as promptly as possible to reports of violations.
+- Make an effort to understand both sides of the situation, including talking to affected participants and reading up on the underlying issues, particularly if they don’t have similar personal experience(s).
+- Keep each other accountable.
+- Trade off duties when needed.
+- Recuse themselves or be excused from handling an incident if they are listed as a possible Code of Conduct violator.
+- Be kept up-to-date in the [Unmock community moderators document](https://github.com/unmock/code-of-conduct/blob/master/moderators.md).
+
+### Additional Items
+Please also note:
+
+- Moderators can choose to close threads or ask for a subject change.
+- Moderators can choose to re-evaluate consequences.
+- Do not delete posts or comments you’ve made unless:
+  - You sincerely made the post in error (like accidentally posting in the wrong group, for example) and
+  - Deleting will not interfere with group discussion. The specific problem we want to address with this rule: Deleting because the conversation has become tense or uncomfortable or to avoid taking responsibility is. Many of us are socialized or naturally prone to avoid conflict, but working through that conflict and acknowledging differing viewpoints is worth the discomfort.
+- This Code of Conduct applies to Unmock community spaces and events, but if you are being or have been harassed by a Unmock community participant externally, you may still report to the Unmock community moderators. We will take all good-faith reports of harassment by community participants seriously. The Unmock community moderators reserve the right to exclude people from the Unmock community and/or Unmock events based on past and/or external behavior towards Unmock community participants or non-participants.
+- We will not name harassment victims without their consent. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of the Unmock community or the general public.
+
+### Code of Conduct Feedback
+Feedback is always appreciated! You can create an [issue in the Github repository](https://github.com/unmock/code-of-conduct/issues).
+
+The Unmock Community Code of Conduct is a living document. It will grow with the Unmock community to ensure we are providing a safe, inclusive, welcoming, and harassment-free space and experience for all community participants.
+
+### Sources
+[Keen IO Community Code of Conduct](https://github.com/keen/community-code-of-conduct)
+
+[LadyNerds Mission and Code of Conduct](http://www.ladynerds.org/code_of_conduct)
+
+[LGBTQ in Technology Code of Conduct](http://lgbtq.technology/coc.html)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,3 +5,7 @@ sidebar_label: Contributing
 ---
 
 Contributions are welcome and encouraged to Unmock! We appreciate [pull requests](https://www.github.com/unmock/unmock-js), [issues](https://www.github.com/unmock/unmock-js) and words of encouragement in our [gitter](https://gitter.im/unmock/community) community!
+
+If you'd like to make improvements to this website or the documentation, you can file issues or open pull requests on our [`unmock/unmock.github.io` repository](https://github.com/unmock/unmock.github.io)
+
+Please note that all of our projects are governed by the [Unmock Community Code of Conduct](https://github.com/unmock/code-of-conduct). By participating, you agree to abide by its terms.

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -47,6 +47,7 @@ class Footer extends React.Component {
           <div>
             <h5>More</h5>
             <a href="https://github.com/unmock">GitHub</a>
+            <a href="https://github.com/unmock/code-of-conduct">Code of Conduct</a>
           </div>
         </section>
         {/*<section className="copyright">{this.props.config.copyright}</section>*/}

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -4,6 +4,7 @@
     "Services": ["unmock", "openapi"],
     "Basic Usage": ["expectations", "setting-state", "fuzz"],
     "Advanced Usage": ["jest-reporter", "configuration"],
+    "Community": ["code-of-conduct"],
     "Roadmap": ["roadmap", "contributing", "about"]
   }
 }


### PR DESCRIPTION
Closes #39 

It's important that our Unmock Community Code of Conduct is clear and accessible, especially on unmock.io since that is our main landing page and documentation site.

