### PR TITLE
Fix the button at the end of the Katacode scenario

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -96,6 +96,8 @@ class Index extends React.Component {
           id="katacoda-scenario-1"
           data-katacoda-id="unmock/introduction"
           data-katacoda-color="004d7f"
+          data-katacoda-ctaurl="https://www.unmock.io/docs/introduction"
+          data-katacoda-ctatext="LEARN MORE"
           style={{
             display: "block",
             margin: "auto",


### PR DESCRIPTION
At the end of the Katacoda scenario, currently a `NEXT SCENARIO` button is shown linking to https://katacoda.com/courses/unmock, which shows `404 - Page Not Found`:

<img width="523" alt="current" src="https://user-images.githubusercontent.com/277251/71895720-21100a00-3152-11ea-9012-c19209191a0b.png">

The button text and link can be customised, and this PR changes the text to "LEARN MORE" and the link to https://www.unmock.io/docs/introduction:

<img width="523" alt="updated" src="https://user-images.githubusercontent.com/277251/71895799-54eb2f80-3152-11ea-86f0-eab5f2705f21.png">