### PR TITLE
Add Packages section

### DIFF
--- a/docs/unmock-runner.md
+++ b/docs/unmock-runner.md
@@ -1,0 +1,39 @@
+---
+id: runner
+title: Unmock Runner
+sidebar_label: unmock-runner
+---
+
+With the [Unmock `runner`](https://github.com/Meeshkan/unmock-js/tree/dev/packages/unmock-runner), you can run any test multiple times with different potential outcomes from the API. All of your unmock tests should use the `runner` unless you are absolutely certain that the API response will be the same every time.
+
+### Default
+
+By default, the `runner` is set to run your test 20 times.
+
+### Jest
+
+A Jest configuration for the `runner` is available through a separate [`unmock-jest-runner`](https://github.com/meeshkan/unmock-jest-runner) package. While the standard `unmock-runner` is available via NPM, you'll want to use the `unmock-jest-runner` when executing your tests to ensure proper error handling. 
+
+The `unmock-jest-runner` can be installed via NPM or Yarn:
+
+```
+npm install -D unmock-jest-runner
+yarn add unmock-jest-runner
+```
+
+Once installed, the `runner` can be imported as a default and used as a wrapper for your tests:
+
+```js
+const runner = require("unmock-jest-runner").default;
+
+test("my API always works as expected", runner(async () => {
+  const res = await myApiFunction();
+  // some expectations
+}));
+```
+
+### Other configurations
+
+As of now, Jest is the only package we have available. 
+
+However, we're currently building out support for [Mocha](https://github.com/Meeshkan/unmock-js/issues/299) and [QUnit](https://github.com/Meeshkan/unmock-js/issues/300). You can follow the progress of those implementations in the corresponding issues.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -4,6 +4,7 @@
     "Services": ["unmock", "openapi"],
     "Basic Usage": ["expectations", "setting-state", "fuzz"],
     "Advanced Usage": ["jest-reporter", "configuration"],
+    "Packages": ["unmock-runner"],
     "Guides": ["react-native"],
     "Community": ["code-of-conduct"],
     "Roadmap": ["roadmap", "contributing", "about"]


### PR DESCRIPTION
While this is still a WIP pull request, I wanted to open it now to get feedback.

I believe it'd be worth while to have a `Packages` section of the documentation that describes what each package within `unmock-js` does and some basic usage. This could also help with onboarding potential contributors. 

I've started with the `unmock-runner` package because I already made related PRs today, but the goal would be to add all of the packages.