### PR TITLE
Fix typo: augmentedUser -> postAugmentedUser

### DIFF
--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -75,7 +75,7 @@ afterEach(() => {
 <!--Code-->
 
 ```javascript
-// augmentedUser.js
+// postAugmentedUser.js
 import axios from "axios";
 
 export default async (id, name, hobby) => {
@@ -187,7 +187,7 @@ afterEach(() => {
 <!--Code-->
 
 ```javascript
-// augmentedUser.js
+// postAugmentedUser.js
 import axios from "axios";
 
 export default async (id, name, hobby) => {


### PR DESCRIPTION
## Description

It's just a tiny typo I saw in the documentation, the file being imported from is called `postAugmentedUser` but it is actually called `augmentedUser`.